### PR TITLE
feat: avoid code duplication in data-code

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,9 +15,8 @@ export function addCopyButton(options: Options = {}): ShikiTransformer {
         'button',
         {
           class: 'copy',
-          'data-code': this.source,
           onclick: `
-          navigator.clipboard.writeText(this.dataset.code);
+          navigator.clipboard.writeText(this.parentElement.innerText);
           this.classList.add('copied');
           setTimeout(() => this.classList.remove('copied'), ${toggleMs})
         `


### PR DESCRIPTION
If you have many different code blocks or very long ones, the previous approach would duplicate all their content and put it in the respective data attribute. 
While that is not wrong by any means, this simple change aims to reduce the size of the final html file.